### PR TITLE
Add production flag to webpack build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "prebuild": "CI=1 npm i cypress",
-    "build": "webpack",
+    "build": "webpack --mode=production",
     "postbuild": "http-server -p 8080 ./dist & npm run e2e && fkill -f :8080",
     "start": "webpack-dev-server --mode=development --progress --config ./webpack.config.ts",
     "test": "jest",


### PR DESCRIPTION
Explicitly adding this flag excludes hot reload files and reduces the production build size to 25kb